### PR TITLE
Enhance JavaDoc comments in HasLogger interface for clarity and context

### DIFF
--- a/src/main/java/com/vaadin/starter/bakery/app/HasLogger.java
+++ b/src/main/java/com/vaadin/starter/bakery/app/HasLogger.java
@@ -4,13 +4,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * HasLogger is a feature interface that provides Logging capability for anyone
- * implementing it where logger needs to operate in serializable environment
- * without being static.
+ * Interface funcional que fornece capacidade de logging para classes que a implementam.
+ * <p>
+ * Útil especialmente em ambientes onde a serialização é necessária, pois evita o uso de campos estáticos.
+ * Ao implementar esta interface, a classe pode obter facilmente um logger SLF4J associado à sua própria classe.
  */
 public interface HasLogger {
 
-	default Logger getLogger() {
-		return LoggerFactory.getLogger(getClass());
-	}
+    /**
+     * Retorna uma instância de {@link Logger} associada à classe que implementa esta interface.
+     * <p>
+     * O logger é obtido dinamicamente com base na classe em tempo de execução, permitindo logging contextualizado.
+     *
+     * @return um logger SLF4J para a classe atual
+     */
+    default Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
+    }
 }


### PR DESCRIPTION
This pull request updates the documentation for the `HasLogger` interface to provide a clearer and more detailed explanation. The comments have been rewritten in Portuguese, and additional Javadoc has been added to the `getLogger()` method for better clarity and context.

Documentation improvements:

* Updated the class-level and method-level Javadoc in `HasLogger.java` to be more descriptive, switching to Portuguese and explaining the purpose and benefits of the interface, especially regarding serialization and contextual logging.